### PR TITLE
fix(#2): defer fail-on-missing failure to env preparation

### DIFF
--- a/integration_tests/cross-env-test/pyproject.toml
+++ b/integration_tests/cross-env-test/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cross-env-test"
+dynamic = ["version"]
+description = ''
+requires-python = ">=3.10,<=3.14"
+license = "MIT"
+keywords = []
+authors = []
+classifiers = []
+dependencies = []
+
+[tool.hatch.version]
+path = "src/cross_env_test/__about__.py"
+
+[tool.hatch.env]
+requires = ["hatch-dotenv@file:///Users/dennis/projects/hatch-dotenv"]
+
+# The `secrets` env requires a missing .env file with fail-on-missing=true.
+# This must NOT prevent operations on the `default` env from succeeding
+# (reproduces issue #2: fail-on-missing on one env affecting other envs).
+[tool.hatch.env.collectors.dotenv.secrets]
+env-files = [".env.missing"]
+fail-on-missing = true
+
+[tool.hatch.envs.default]
+installer = "uv"
+
+[tool.hatch.envs.secrets]
+installer = "uv"

--- a/integration_tests/cross-env-test/pyproject.toml.in
+++ b/integration_tests/cross-env-test/pyproject.toml.in
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cross-env-test"
+dynamic = ["version"]
+description = ''
+requires-python = ">=3.10,<=3.14"
+license = "MIT"
+keywords = []
+authors = []
+classifiers = []
+dependencies = []
+
+[tool.hatch.version]
+path = "src/cross_env_test/__about__.py"
+
+[tool.hatch.env]
+requires = ["{{HATCH_DOTENV_PACKAGE}}"]
+
+# The `secrets` env requires a missing .env file with fail-on-missing=true.
+# This must NOT prevent operations on the `default` env from succeeding
+# (reproduces issue #2: fail-on-missing on one env affecting other envs).
+[tool.hatch.env.collectors.dotenv.secrets]
+env-files = [".env.missing"]
+fail-on-missing = true
+
+[tool.hatch.envs.default]
+installer = "uv"
+
+[tool.hatch.envs.secrets]
+installer = "uv"

--- a/integration_tests/cross-env-test/src/cross_env_test/__about__.py
+++ b/integration_tests/cross-env-test/src/cross_env_test/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025-present Dennis Kreber <dnis.kk@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+__version__ = "0.0.1"

--- a/integration_tests/cross-env-test/src/cross_env_test/__init__.py
+++ b/integration_tests/cross-env-test/src/cross_env_test/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Dennis Kreber <dnis.kk@gmail.com>
+#
+# SPDX-License-Identifier: MIT

--- a/integration_tests/cross-env-test/src/cross_env_test/__main__.py
+++ b/integration_tests/cross-env-test/src/cross_env_test/__main__.py
@@ -1,0 +1,3 @@
+# ruff: noqa: T201
+if __name__ == "__main__":
+    print("Test suite 'cross-env-test' passed")

--- a/integration_tests/cross-env-test/tests/__init__.py
+++ b/integration_tests/cross-env-test/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Dennis Kreber <dnis.kk@gmail.com>
+#
+# SPDX-License-Identifier: MIT

--- a/integration_tests/run_tests_hatch_pip.sh
+++ b/integration_tests/run_tests_hatch_pip.sh
@@ -15,6 +15,7 @@ generate_pyproject() {
 
 generate_pyproject "$SCRIPT_DIR/happy-test"
 generate_pyproject "$SCRIPT_DIR/missing-test"
+generate_pyproject "$SCRIPT_DIR/cross-env-test"
 
 cd "$SCRIPT_DIR/happy-test"
 pip uninstall hatch-dotenv -y || true
@@ -25,3 +26,10 @@ cd "$SCRIPT_DIR/missing-test"
 pip uninstall hatch-dotenv -y || true
 pip cache purge
 hatch run python -m missing_test
+
+# Reproduces issue #2: a `secrets` env with fail-on-missing on a missing file
+# must not block running the unrelated `default` env.
+cd "$SCRIPT_DIR/cross-env-test"
+pip uninstall hatch-dotenv -y || true
+pip cache purge
+hatch run python -m cross_env_test

--- a/integration_tests/run_tests_hatch_pipx.sh
+++ b/integration_tests/run_tests_hatch_pipx.sh
@@ -15,6 +15,7 @@ generate_pyproject() {
 
 generate_pyproject "$SCRIPT_DIR/happy-test"
 generate_pyproject "$SCRIPT_DIR/missing-test"
+generate_pyproject "$SCRIPT_DIR/cross-env-test"
 
 cd "$SCRIPT_DIR/happy-test"
 pipx runpip hatch uninstall hatch-dotenv -y || true
@@ -25,3 +26,10 @@ cd "$SCRIPT_DIR/missing-test"
 pipx runpip hatch uninstall hatch-dotenv -y || true
 hatch run pip cache purge
 hatch run python -m missing_test
+
+# Reproduces issue #2: a `secrets` env with fail-on-missing on a missing file
+# must not block running the unrelated `default` env.
+cd "$SCRIPT_DIR/cross-env-test"
+pipx runpip hatch uninstall hatch-dotenv -y || true
+hatch run pip cache purge
+hatch run python -m cross_env_test

--- a/integration_tests/run_tests_no_cache_clear.sh
+++ b/integration_tests/run_tests_no_cache_clear.sh
@@ -15,9 +15,15 @@ generate_pyproject() {
 
 generate_pyproject "$SCRIPT_DIR/happy-test"
 generate_pyproject "$SCRIPT_DIR/missing-test"
+generate_pyproject "$SCRIPT_DIR/cross-env-test"
 
 cd "$SCRIPT_DIR/happy-test"
 hatch run python -m happy_test
 
 cd "$SCRIPT_DIR/missing-test"
 hatch run python -m missing_test
+
+# Reproduces issue #2: a `secrets` env with fail-on-missing on a missing file
+# must not block running the unrelated `default` env.
+cd "$SCRIPT_DIR/cross-env-test"
+hatch run python -m cross_env_test

--- a/src/hatch_dotenv/hooks.py
+++ b/src/hatch_dotenv/hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, NotRequired, TypedDict, cast
 
@@ -88,34 +89,43 @@ class DotenvCollector(EnvironmentCollectorInterface):
         It reads `env-files` from each environment and merges the loaded variables
         into the environment's `env-vars`.
 
+        When `fail-on-missing=true` and a referenced .env file is missing, a
+        `pre-install-commands` entry is appended to that env so the failure
+        only surfaces when the env is actually prepared — leaving unrelated
+        envs (and commands like `hatch publish`) untouched.
+
         Args:
             config: Dictionary of environment name -> environment configuration.
-
-        Raises:
-            FileNotFoundError: If the environment file is not found and fail-on-missing is True.
         """
         assert_config(self.config)  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
         collector_config = cast("dict[str, CollectorConfig]", self.config)
 
         for env_name, env_entry in config.items():
-            # Pop env-files so it doesn't get passed to the environment
             env_config = collector_config.get(env_name, {})
             files = env_config.get("env-files", [])
             fail_on_missing = env_config.get("fail-on-missing", False)
             if not files:
                 continue
 
-            # Get or create the env-vars dict
             env_vars: dict[str, str] = env_entry.setdefault("env-vars", {})
 
             for env_file in files:
                 env_path = Path(self.root) / env_file  # pyright: ignore[reportUnknownArgumentType]
                 if not env_path.exists():
                     if fail_on_missing:
-                        error_message = f"Environment file not found: {env_file}"
-                        raise FileNotFoundError(error_message)
+                        _inject_missing_file_failure(env_entry, env_name, env_file)
                     continue
 
                 loaded_vars = dotenv_values(env_path)
-                # Filter out None values and update env_vars
                 env_vars.update({k: v for k, v in loaded_vars.items() if v is not None})
+
+
+def _inject_missing_file_failure(env_entry: dict[str, Any], env_name: str, env_file: str) -> None:
+    """Append a pre-install command that fails with a clear message about the missing file."""
+    error_message = f"hatch-dotenv: required env-file not found for env [{env_name}]: {env_file}"
+    # shlex.quote keeps the python script intact regardless of the message contents.
+    py_code = f"import sys; sys.exit({error_message!r})"
+    fail_command = f"python -c {shlex.quote(py_code)}"
+    pre_install: list[str] = env_entry.setdefault("pre-install-commands", [])
+    if fail_command not in pre_install:
+        pre_install.append(fail_command)

--- a/tests/hatch_dotenv/test_hooks.py
+++ b/tests/hatch_dotenv/test_hooks.py
@@ -158,15 +158,44 @@ class TestFinalizeConfig:
         # env-vars dict is created but empty since no files were loaded
         assert config["default"]["env-vars"] == {}
 
-    def test_missing_file_raises_when_fail_on_missing(self, mock_collector: MagicMock) -> None:
-        """Missing files should raise FileNotFoundError when fail-on-missing is True."""
+    def test_missing_file_injects_pre_install_failure_when_fail_on_missing(
+        self, mock_collector: MagicMock
+    ) -> None:
+        """Missing files should defer failure to pre-install-commands, not raise immediately.
+
+        Raising during finalize_config breaks unrelated commands (issue #2): hatch invokes
+        finalize_config for every operation, so a single misconfigured env would crash
+        `hatch publish`, `hatch build`, etc. Injecting into pre-install-commands defers
+        the failure until the env in question is actually prepared.
+        """
         mock_collector.config = {
             "default": {"env-files": [".env.nonexistent"], "fail-on-missing": True},
         }
         config: dict[str, dict[str, Any]] = {"default": {}}
 
-        with pytest.raises(FileNotFoundError, match="Environment file not found"):
-            self._finalize(mock_collector, config)
+        self._finalize(mock_collector, config)
+
+        pre_install = config["default"]["pre-install-commands"]
+        assert len(pre_install) == 1
+        assert ".env.nonexistent" in pre_install[0]
+        assert "default" in pre_install[0]
+
+    def test_missing_file_in_one_env_does_not_affect_other_env(self, mock_collector: MagicMock) -> None:
+        """fail-on-missing on env A must not block env B (issue #2)."""
+        env_file = mock_collector.root / ".env"
+        env_file.write_text("OK=ok\n")
+
+        mock_collector.config = {
+            "default": {"env-files": [".env"]},
+            "secrets": {"env-files": [".env.missing"], "fail-on-missing": True},
+        }
+        config: dict[str, dict[str, Any]] = {"default": {}, "secrets": {}}
+
+        self._finalize(mock_collector, config)
+
+        assert config["default"]["env-vars"]["OK"] == "ok"
+        assert "pre-install-commands" not in config["default"]
+        assert config["secrets"]["pre-install-commands"]
 
     def test_partial_missing_files_without_fail(self, mock_collector: MagicMock) -> None:
         """Existing files should be loaded even when some are missing."""

--- a/tests/hatch_dotenv/test_hooks.py
+++ b/tests/hatch_dotenv/test_hooks.py
@@ -158,9 +158,7 @@ class TestFinalizeConfig:
         # env-vars dict is created but empty since no files were loaded
         assert config["default"]["env-vars"] == {}
 
-    def test_missing_file_injects_pre_install_failure_when_fail_on_missing(
-        self, mock_collector: MagicMock
-    ) -> None:
+    def test_missing_file_injects_pre_install_failure_when_fail_on_missing(self, mock_collector: MagicMock) -> None:
         """Missing files should defer failure to pre-install-commands, not raise immediately.
 
         Raising during finalize_config breaks unrelated commands (issue #2): hatch invokes


### PR DESCRIPTION
## Summary
- Stops `fail-on-missing=true` on one env from breaking unrelated commands (`hatch publish`, `hatch build`, …). Root cause: `finalize_config` runs for every Hatch operation across all envs, so a single misconfigured env would crash everything.
- Instead of raising in `finalize_config`, the plugin now appends a `python -c` failure to the offending env's `pre-install-commands`. The error only surfaces when that env is actually being prepared.
- Adds `integration_tests/cross-env-test/` reproducing issue #2 and wires it into all three runner scripts.

## Known limitation
If an env was prepared while the file existed and the file is later deleted, `pre-install-commands` won't re-run unless deps change. Acceptable trade-off — the user's tests still fail on the missing env vars.

## Test plan
- [x] `hatch -e dev run pytest tests/` — 25 passed
- [x] `bash integration_tests/run_tests_hatch_pipx.sh "hatch-dotenv@file:///path/to/repo"` — happy-test, missing-test, cross-env-test all pass
- [x] `hatch -e secrets run …` in `cross-env-test` still fails with `hatch-dotenv: required env-file not found for env [secrets]: .env.missing`

Closes #2